### PR TITLE
Made the argument useLevenshtein work

### DIFF
--- a/lib/fuzzyset.js
+++ b/lib/fuzzyset.js
@@ -9,7 +9,7 @@ var FuzzySet = function(arr, useLevenshtein, gramSizeLower, gramSizeUpper) {
     arr = arr || [];
     fuzzyset.gramSizeLower = gramSizeLower || 2;
     fuzzyset.gramSizeUpper = gramSizeUpper || 3;
-    fuzzyset.useLevenshtein = useLevenshtein || true;
+    fuzzyset.useLevenshtein = (typeof useLevenshtein !== 'boolean') ? true : useLevenshtein;
 
     // define all the object functions and attributes
     fuzzyset.exactSet = {};


### PR DESCRIPTION
Bugfix: The argument useLevenshtein couldn't be set to false before