### PR TITLE
Add support for jspm/SystemJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/fuzzyset.js');
+module.exports = require('./lib/fuzzyset');


### PR DESCRIPTION
The addition of the `.js` causes issues when including fuzzyset as a dependency via [jspm](https://github.com/jspm/jspm-cli).   AFAIK the suffix is not required so simply removed it which works as before + jspm. 