### PR TITLE
Add support for characters like german umlauts and the likes

### DIFF
--- a/lib/fuzzyset.js
+++ b/lib/fuzzyset.js
@@ -50,7 +50,7 @@ var FuzzySet = function(arr, useLevenshtein, gramSizeLower, gramSizeUpper) {
             return 1 - distance / str2.length;
         }
     };
-    var _nonWordRe = /[^\w, ]+/;
+    var _nonWordRe = /[^a-zA-Z0-9\u00C0-\u00FF, ]+/;
 
     var _iterateGrams = function(value, gramSize) {
         gramSize = gramSize || 2;


### PR DESCRIPTION
Hey there,

i just had some issues matching strings which contain umlauts and accented characters. It's because the `\w` character class for matching non-word characters doesn't match these characters and therefore removes them.

I'm haven't tested in detail how the distance calculation deals with umlauts but it works for me so far .