### PR TITLE
don't specify a protocol so the website's example can work in both http and https

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ a.get("micael asiak");
 
         </div> <!-- /container -->
 
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 
         <script src="site/js/vendor/bootstrap.min.js"></script>
 


### PR DESCRIPTION
Currently, the website's example only works with http cause the browser blocks mixed content.

> Mixed Content: The page at 'https://glench.github.io/fuzzyset.js/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.

That is because the jquery lib which is loaded from googleapi's cdn specifies a protocol, removing it will fix the issue.