### PR TITLE
fix export for node strict mode

### DIFF
--- a/lib/fuzzyset.js
+++ b/lib/fuzzyset.js
@@ -2,7 +2,7 @@
 
 var FuzzySet = function(arr, useLevenshtein, gramSizeLower, gramSizeUpper) {
     var fuzzyset = {
-        
+
     };
 
     // default options
@@ -287,7 +287,10 @@ var root = this;
 // global object.
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = FuzzySet;
-    root.FuzzySet = FuzzySet;
+    if(root)
+    {
+        root.FuzzySet = FuzzySet;
+    }
 } else {
     root.FuzzySet = FuzzySet;
 }


### PR DESCRIPTION
When using node in strict mode, importing package fails because there is no `this` object:

```
node --use_strict index.js

/web/xxx/node_modules/fuzzyset.js/lib/fuzzyset.js:290
    root.FuzzySet = FuzzySet;
                  ^

TypeError: Cannot set property 'FuzzySet' of undefined
    at /web/xxx/node_modules/fuzzyset.js/lib/fuzzyset.js:290:19
```
So I added a simple check.