### PR TITLE
allow values to be objects with a specified key for search

### DIFF
--- a/lib/fuzzyset.js
+++ b/lib/fuzzyset.js
@@ -1,15 +1,17 @@
 (function() {
 
-var FuzzySet = function(arr, useLevenshtein, gramSizeLower, gramSizeUpper) {
+var FuzzySet = function(arr, key, ops) {
     var fuzzyset = {
 
     };
 
     // default options
     arr = arr || [];
-    fuzzyset.gramSizeLower = gramSizeLower || 2;
-    fuzzyset.gramSizeUpper = gramSizeUpper || 3;
-    fuzzyset.useLevenshtein = (typeof useLevenshtein !== 'boolean') ? true : useLevenshtein;
+    ops = ops || {};
+		fuzzyset.key = key
+    fuzzyset.gramSizeLower = ops.gramSizeLower || 2;
+    fuzzyset.gramSizeUpper = ops.gramSizeUpper || 3;
+    fuzzyset.useLevenshtein = (typeof ops.useLevenshtein !== 'boolean') ? true : ops.useLevenshtein;
 
     // define all the object functions and attributes
     fuzzyset.exactSet = {};
@@ -187,7 +189,7 @@ var FuzzySet = function(arr, useLevenshtein, gramSizeLower, gramSizeUpper) {
     };
 
     fuzzyset.add = function(value) {
-        var normalizedValue = this._normalizeStr(value);
+        var normalizedValue = this._normalizeStr(value[key]);
         if (normalizedValue in this.exactSet) {
             return false;
         }
@@ -199,7 +201,7 @@ var FuzzySet = function(arr, useLevenshtein, gramSizeLower, gramSizeUpper) {
     };
 
     fuzzyset._add = function(value, gramSize) {
-        var normalizedValue = this._normalizeStr(value),
+        var normalizedValue = this._normalizeStr(value[key]),
             items = this.items[gramSize] || [],
             index = items.length;
 


### PR DESCRIPTION
Just discovered fuzzyset and it's amazing - **fast**, which I need.  However, my use case absolutely *needs* objects to be stored and retrieved from the search.  It only took two lines of code and an extra argument input.

Thought I'd share it :)

Obviously if you're mixing strings and objects you'll need some error handling and checking, but that shouldn't be too much extra work!  I wouldn't be able to use vanilla fuzzyset.js without these modifications, and I'm sure having objects as input would be a huge benefit to others out there.

Anyway, just thought I'd share in case you're interested in using objects also :)