### PR TITLE
fix(README.MD): fix case sensitive import

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ npm install fuzzyset
 
 Then:
 ```javascript
-import FuzzySet from 'FuzzySet'
+import FuzzySet from 'fuzzyset'
 
 // or, depending on your JavaScript environment...
 


### PR DESCRIPTION
I know this may seem like a small change, but I almost forgot about case sensitivity when I installed this on linux.

The fix is just a 1 line change on the readme.

Great work btw!